### PR TITLE
Remove verificação padrão de PR

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -20,7 +20,6 @@ type_tags:
 is_requires_admin_user: false
 is_always_run: false
 is_skippable: false
-run_if: ".IsPR"
 
 deps:
   brew:


### PR DESCRIPTION
Atualmente a step roda apenas se a flag `.IsPR` for true, o que não é necessário para o nosso caso